### PR TITLE
Insert buffer-file-name as FILE if pdf-view-mode is active

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,6 +16,12 @@ is displayed, the matching regions are highlighted.
 (pdfgrep-mode)
 #+end_src
 
+* Running tests
+
+  #+begin_src bash
+emacs --batch -l pdfgrep.el -l pdfgrep-tests.el -f ert-run-tests-batch-and-exit
+  #+end_src
+
 * Example
 
 [[./screenshot.png]]

--- a/pdfgrep-tests.el
+++ b/pdfgrep-tests.el
@@ -1,0 +1,80 @@
+;;; pdfgrep-tests.el --- Test for pdf-grep   -*- lexical-binding: t; -*-
+
+
+;;; Commentary:
+
+;;; Code:
+
+
+(require 'ert)
+(require 'pdfgrep)
+
+(defun pth/pos-at-end (cmd)
+  "Position at end of CMD. Counting begins at 1."
+  (1+ (length cmd)))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/ignore-case ()
+  (let ((cmd "pdfgrep -H -n -i "))
+    (should (equal (pdfgrep-default-command) cmd))))
+
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case ()
+  (let ((pdfgrep-ignore-case 'nil)
+        (cmd "pdfgrep -H -n "))
+    (should (equal (pdfgrep-default-command) cmd))))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case-pdf-view-mode ()
+  (let* ((pdfgrep-ignore-case 'nil)
+         (major-mode 'pdf-view-mode)
+         (buffer-file-name "/some/path/to/test.pdf")
+         (base-cmd "pdfgrep -H -n ")
+         (cmd (concat base-cmd buffer-file-name)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end cmd))))))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case-doc-view-mode ()
+  (let* ((pdfgrep-ignore-case 'nil)
+         (major-mode 'doc-view-mode)
+         (buffer-file-name "/some/path/to/test.pdf")
+         (base-cmd "pdfgrep -H -n ")
+         (cmd (concat base-cmd buffer-file-name)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end cmd))))))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/ignore-case-ignore-errors ()
+  (let* ((pdfgrep-ignore-errors t)
+         (base-cmd "pdfgrep -H -n -i ")
+         (ignore-errors " 2>/dev/null")
+         (cmd (concat base-cmd ignore-errors)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end base-cmd))))))
+
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case-ignore-errors ()
+  (let* ((pdfgrep-ignore-errors t)
+         (pdfgrep-ignore-case 'nil)
+         (base-cmd "pdfgrep -H -n ")
+         (ignore-errors " 2>/dev/null")
+         (cmd (concat base-cmd ignore-errors)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end base-cmd))))))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case-pdf-view-mode ()
+  (let* ((pdfgrep-ignore-errors t)
+         (pdfgrep-ignore-case 'nil)
+         (major-mode 'pdf-view-mode)
+         (buffer-file-name "/some/path/to/test.pdf")
+         (base-cmd "pdfgrep -H -n ")
+         (ignore-errors " 2>/dev/null")
+         (cmd (concat base-cmd buffer-file-name ignore-errors)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end cmd))))))
+
+(ert-deftest pdfgrep-tests/pdfgrep-default-command/no-ignore-case-doc-view-mode ()
+  (let* ((pdfgrep-ignore-errors t)
+         (pdfgrep-ignore-case 'nil)
+         (major-mode 'doc-view-mode)
+         (buffer-file-name "/some/path/to/test.pdf")
+         (base-cmd "pdfgrep -H -n ")
+         (ignore-errors " 2>/dev/null")
+         (cmd (concat base-cmd buffer-file-name ignore-errors)))
+    (should (equal (pdfgrep-default-command) `(,cmd . ,(pth/pos-at-end cmd))))))
+
+(provide 'pdfgrep-tests)
+
+;;; pdfgrep-tests.el ends here

--- a/pdfgrep.el
+++ b/pdfgrep.el
@@ -61,11 +61,19 @@ Not including `pdfgrep-ignore-case'."
 
 (defun pdfgrep-default-command ()
   "Compute the default pdfgrep command for `pdfgrep'."
-  (let ((cmd (concat pdfgrep-program pdfgrep-options
-		     (when pdfgrep-ignore-case
-		       "-i "))))
+  (let* ((supported-major-modes '(pdf-view-mode doc-view-mode))
+         (is-in-supported-major-mode (member major-mode supported-major-modes))
+         (cmd (concat pdfgrep-program pdfgrep-options
+		              (when pdfgrep-ignore-case
+		                "-i ")
+                      (when is-in-supported-major-mode
+                        buffer-file-name))))
     (if pdfgrep-ignore-errors
-	(cons (concat cmd " 2>/dev/null") (1+ (length cmd)))
+        (let ((cmd-ignore-errors (concat cmd " 2>/dev/null")))
+	      (cons cmd-ignore-errors
+                (if is-in-supported-major-mode
+                    (+ 1 (length cmd-ignore-errors)) ;; we already inserted the file name, set position end of cmd
+                  (1+ (length cmd))))) ;; position at FILE position
       cmd)))
 
 (defun pdfgrep (command-args)


### PR DESCRIPTION
- checks if pdf-view-mode is active
- if it's active it inserts the file name of the currently loaded pdf as PATTERN

@jeremy-compostella I know the code could be cleaner but I wanted to first check if you are generally interested in this change?